### PR TITLE
[OSRA-120] Allow passing search params as constraints to ERDDAP Source Objects

### DIFF
--- a/intake_erddap/erddap_cat.py
+++ b/intake_erddap/erddap_cat.py
@@ -36,6 +36,7 @@ class ERDDAPCatalog(Catalog):
         kwargs_search: MutableMapping[str, Union[str, int, float]] = None,
         category_search: Optional[Tuple[str, str]] = None,
         erddap_client: Optional[Type[ERDDAP]] = None,
+        use_source_constraints: bool = True,
         **kwargs,
     ):
         """ERDDAPCatalog initialization
@@ -57,9 +58,14 @@ class ERDDAPCatalog(Catalog):
             custom_criteria key to narrow the search by, which will be matched to the category results
             using the custom_criteria that must be set up or input by the user, with `cf-pandas`.
             Currently only a single key can be matched at a time.
+        use_source_constraints : bool, default True
+            Any relevant search parameter defined in kwargs_search will be
+            passed to the source objects as contraints.
+
         """
         self._erddap_client = erddap_client or ERDDAP
         self._entries: Dict[str, LocalCatalogEntry] = {}
+        self._use_source_contraints = use_source_constraints
         self.server = server
         self.search_url = None
 
@@ -134,9 +140,9 @@ class ERDDAPCatalog(Catalog):
                 "protocol": "tabledap",
                 "constraints": {},
             }
-            if "min_time" in self.kwargs_search:
+            if self._use_source_contraints and "min_time" in self.kwargs_search:
                 args["constraints"]["time>="] = self.kwargs_search["min_time"]
-            if "max_time" in self.kwargs_search:
+            if self._use_source_contraints and "max_time" in self.kwargs_search:
                 args["constraints"]["time<="] = self.kwargs_search["max_time"]
 
             entry = LocalCatalogEntry(

--- a/intake_erddap/erddap_cat.py
+++ b/intake_erddap/erddap_cat.py
@@ -1,6 +1,6 @@
 """Catalog implementation for intake-erddap."""
 
-from typing import Dict, Optional, Tuple, Type, Union
+from typing import Dict, MutableMapping, Optional, Tuple, Type, Union
 
 import pandas as pd
 
@@ -33,7 +33,7 @@ class ERDDAPCatalog(Catalog):
     def __init__(
         self,
         server: str,
-        kwargs_search: Dict[str, Union[str, int, float]] = None,
+        kwargs_search: MutableMapping[str, Union[str, int, float]] = None,
         category_search: Optional[Tuple[str, str]] = None,
         erddap_client: Optional[Type[ERDDAP]] = None,
         **kwargs,
@@ -59,6 +59,7 @@ class ERDDAPCatalog(Catalog):
             Currently only a single key can be matched at a time.
         """
         self._erddap_client = erddap_client or ERDDAP
+        self._entries: Dict[str, LocalCatalogEntry] = {}
         self.server = server
         self.search_url = None
 
@@ -131,7 +132,12 @@ class ERDDAPCatalog(Catalog):
                 "server": self.server,
                 "dataset_id": dataset_id,
                 "protocol": "tabledap",
+                "constraints": {},
             }
+            if "min_time" in self.kwargs_search:
+                args["constraints"]["time>="] = self.kwargs_search["min_time"]
+            if "max_time" in self.kwargs_search:
+                args["constraints"]["time<="] = self.kwargs_search["max_time"]
 
             entry = LocalCatalogEntry(
                 dataset_id,

--- a/tests/test_erddap_cat.py
+++ b/tests/test_erddap_cat.py
@@ -190,3 +190,9 @@ def test_constraints_present_in_source(mock_read_csv, single_dataset_catalog):
     source = next(cat.values())
     assert source._constraints["time>="] == "2022-01-01"
     assert source._constraints["time<="] == "2022-11-07"
+
+    cat = ERDDAPCatalog(
+        server=server, kwargs_search=search, use_source_constraints=False
+    )
+    source = next(cat.values())
+    assert len(source._constraints) == 0


### PR DESCRIPTION
This PR updates the catalog's `_load` method to pass certain search parameters as dataset constraints. If a client creates a catalog with a temporal search, the temporal search parameters should be passed to the Source as a constraint.