### PR TITLE
[OSRA-127] [OSRA-130] Adds metadata to source objects

### DIFF
--- a/tests/test_erddap_cat.py
+++ b/tests/test_erddap_cat.py
@@ -45,9 +45,11 @@ def temporary_catalog():
             os.unlink(path)
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_erddap_catalog(mock_read_csv):
+def test_erddap_catalog(mock_read_csv, load_metadata_mock):
     """Test basic catalog API."""
+    load_metadata_mock.return_value = {}
     results = pd.DataFrame()
     results["datasetID"] = ["abc123"]
     mock_read_csv.return_value = results
@@ -55,9 +57,11 @@ def test_erddap_catalog(mock_read_csv):
     assert list(cat) == ["abc123"]
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_erddap_catalog_searching(mock_read_csv):
+def test_erddap_catalog_searching(mock_read_csv, load_metadata_mock):
     """Test catalog with search parameters."""
+    load_metadata_mock.return_value = {}
     results = pd.DataFrame()
     results["datasetID"] = ["abc123"]
     mock_read_csv.return_value = results
@@ -73,8 +77,10 @@ def test_erddap_catalog_searching(mock_read_csv):
     assert list(cat) == ["abc123"]
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_erddap_catalog_searching_variable(mock_read_csv):
+def test_erddap_catalog_searching_variable(mock_read_csv, load_metadata_mock):
+    load_metadata_mock.return_value = {}
     df1 = pd.DataFrame()
     df1["Category"] = ["sea_water_temperature"]
     df1["URL"] = ["http://blah.com"]
@@ -115,12 +121,16 @@ def test_ioos_erddap_catalog_and_source():
         "min_time": "2021-4-1",
         "max_time": "2021-4-2",
     }
-    cat_sensors = intake.open_erddap_cat(server=SERVER_URL, kwargs_search=kw)
+    cat_sensors = intake.open_erddap_cat(
+        server="https://erddap.sensors.ioos.us/erddap", kwargs_search=kw
+    )
     source = cat_sensors["gov_noaa_water_wstr1"]
     df = source.read()
     assert df is not None
     assert isinstance(df, pd.DataFrame)
     assert len(df) > 0
+    for dataset_id in cat_sensors:
+        assert cat_sensors[dataset_id].metadata["institution"] is not None
 
 
 def test_invalid_kwarg_search():
@@ -147,8 +157,12 @@ def test_invalid_kwarg_search():
         intake.open_erddap_cat(server=SERVER_URL, kwargs_search=kw)
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_catalog_uses_di_client(mock_read_csv, single_dataset_catalog):
+def test_catalog_uses_di_client(
+    mock_read_csv, load_metadata_mock, single_dataset_catalog
+):
+    load_metadata_mock.return_value = {}
     """Tests that the catalog uses the dependency injection provided client."""
     mock_read_csv.return_value = single_dataset_catalog
     mock_erddap_client = mock.create_autospec(ERDDAP)
@@ -157,8 +171,10 @@ def test_catalog_uses_di_client(mock_read_csv, single_dataset_catalog):
     assert isinstance(client, mock.NonCallableMagicMock)
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_catalog_skips_all_datasets_row(mock_read_csv):
+def test_catalog_skips_all_datasets_row(mock_read_csv, load_metadata_mock):
+    load_metadata_mock.return_value = {}
     """Tests that the catalog results ignore allDatasets special dataset."""
     df = pd.DataFrame()
     df["datasetID"] = ["allDatasets", "abc123"]
@@ -167,8 +183,10 @@ def test_catalog_skips_all_datasets_row(mock_read_csv):
     assert list(cat) == ["abc123"]
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_params_search(mock_read_csv):
+def test_params_search(mock_read_csv, load_metadata_mock):
+    load_metadata_mock.return_value = {}
     df = pd.DataFrame()
     df["datasetID"] = ["allDatasets", "abc123"]
     mock_read_csv.return_value = df
@@ -194,8 +212,12 @@ def test_params_search(mock_read_csv):
     assert query["standard_name"] == "sea_water_temperature"
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_constraints_present_in_source(mock_read_csv, single_dataset_catalog):
+def test_constraints_present_in_source(
+    mock_read_csv, load_metadata_mock, single_dataset_catalog
+):
+    load_metadata_mock.return_value = {}
     mock_read_csv.return_value = single_dataset_catalog
     search = {
         "min_time": "2022-01-01",
@@ -213,8 +235,12 @@ def test_constraints_present_in_source(mock_read_csv, single_dataset_catalog):
     assert len(source._constraints) == 0
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_catalog_with_griddap(mock_read_csv, single_dataset_catalog):
+def test_catalog_with_griddap(
+    mock_read_csv, load_metadata_mock, single_dataset_catalog
+):
+    load_metadata_mock.return_value = {}
     mock_read_csv.return_value = single_dataset_catalog
     search = {
         "min_time": "2022-01-01",
@@ -225,8 +251,12 @@ def test_catalog_with_griddap(mock_read_csv, single_dataset_catalog):
     assert isinstance(source, GridDAPSource)
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_catalog_with_unsupported_protocol(mock_read_csv, single_dataset_catalog):
+def test_catalog_with_unsupported_protocol(
+    mock_read_csv, load_metadata_mock, single_dataset_catalog
+):
+    load_metadata_mock.return_value = {}
     search = {
         "min_time": "2022-01-01",
         "max_time": "2022-11-07",
@@ -236,8 +266,12 @@ def test_catalog_with_unsupported_protocol(mock_read_csv, single_dataset_catalog
         ERDDAPCatalog(server=SERVER_URL, kwargs_search=search, protocol="fakedap")
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_catalog_get_search_urls_by_category(mock_read_csv, single_dataset_catalog):
+def test_catalog_get_search_urls_by_category(
+    mock_read_csv, load_metadata_mock, single_dataset_catalog
+):
+    load_metadata_mock.return_value = {}
     mock_read_csv.return_value = single_dataset_catalog
     kwargs_search = {
         "standard_name": ["air_pressure", "air_temperature"],
@@ -249,8 +283,12 @@ def test_catalog_get_search_urls_by_category(mock_read_csv, single_dataset_catal
     assert len(search_urls) == 6
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_catalog_query_search_for(mock_read_csv, single_dataset_catalog):
+def test_catalog_query_search_for(
+    mock_read_csv, load_metadata_mock, single_dataset_catalog
+):
+    load_metadata_mock.return_value = {}
     mock_read_csv.return_value = single_dataset_catalog
     kwargs_search = {
         "search_for": ["air_pressure", "air_temperature"],
@@ -268,22 +306,28 @@ def test_catalog_query_search_for(mock_read_csv, single_dataset_catalog):
     assert query["searchFor"] == "air_temperature"
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_search_returns_404(mock_read_csv, single_dataset_catalog):
+def test_search_returns_404(mock_read_csv, load_metadata_mock):
+    load_metadata_mock.return_value = {}
     mock_read_csv.side_effect = HTTPError(
-        code=404, msg="Blah", url=SERVER_URL, hdrs={}, fp={}
+        code=404, msg="Blah", url=SERVER_URL, hdrs={}, fp=None
     )
     with pytest.raises(ValueError):
         ERDDAPCatalog(server=SERVER_URL)
     mock_read_csv.side_effect = HTTPError(
-        code=500, msg="Blah", url=SERVER_URL, hdrs={}, fp={}
+        code=500, msg="Blah", url=SERVER_URL, hdrs={}, fp=None
     )
     with pytest.raises(HTTPError):
         ERDDAPCatalog(server=SERVER_URL)
 
 
+@mock.patch("intake_erddap.erddap_cat.ERDDAPCatalog._load_metadata")
 @mock.patch("pandas.read_csv")
-def test_saving_catalog(mock_read_csv, single_dataset_catalog, temporary_catalog):
+def test_saving_catalog(
+    mock_read_csv, load_metadata_mock, single_dataset_catalog, temporary_catalog
+):
+    load_metadata_mock.return_value = {}
     mock_read_csv.return_value = single_dataset_catalog
     cat = ERDDAPCatalog(server=SERVER_URL)
     cat.save(temporary_catalog)
@@ -304,3 +348,17 @@ def test_saving_catalog(mock_read_csv, single_dataset_catalog, temporary_catalog
     assert source._protocol == "griddap"
     assert source._server == SERVER_URL
     assert source._dataset_id == "abc123"
+
+
+@mock.patch("intake_erddap.utils.get_erddap_metadata")
+@mock.patch("pandas.read_csv")
+def test_loading_metadata(
+    mock_read_csv, mock_get_erddap_metadata, single_dataset_catalog
+):
+    mock_read_csv.return_value = single_dataset_catalog
+    mock_get_erddap_metadata.return_value = {
+        "abc123": {"datasetID": "abc123", "institution": "FOMO"}
+    }
+
+    cat = ERDDAPCatalog(server=SERVER_URL)
+    assert cat["abc123"].metadata["institution"] == "FOMO"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Tests for generic and utility functions."""
 from unittest import mock
+from urllib.parse import parse_qsl, urlparse
 
 import pandas as pd
 
@@ -33,3 +34,64 @@ def test_category_and_key(mock_read_csv):
         server, "wind_s", "standard_name", criteria
     )
     assert match_to_key == ["wind_speed"]
+
+
+@mock.patch("requests.get")
+def test_get_erddap_metadata(requests_mock):
+    resp = mock.MagicMock()
+    resp.json.return_value = {
+        "table": {
+            "columnNames": [
+                "datasetID",
+                "some_string",
+                "some_int",
+                "some_float",
+                "some_double",
+            ],
+            "columnTypes": [
+                "String",
+                "String",
+                "int",
+                "float",
+                "double",
+            ],
+            "rows": [
+                ["abc123", "value", "1", "2.0", "3.0"],
+            ],
+        }
+    }
+    requests_mock.return_value = resp
+
+    server = "https://erddap.invalid/erddap"
+    data = utils.get_erddap_metadata(server=server, constraints={})
+    assert len(data) == 1
+    assert data["abc123"]
+    assert data["abc123"]["some_string"] == "value"
+    assert data["abc123"]["some_int"] == 1
+    assert data["abc123"]["some_float"] == 2.0
+    assert data["abc123"]["some_double"] == 3.0
+    assert requests_mock.call_args.args == (
+        "https://erddap.invalid/erddap/tabledap/allDatasets.json?datasetID%2Cinstitution%2Ctitle"
+        "%2Csummary%2CminLongitude%2CmaxLongitude%2CminLatitude%2CmaxLatitude%2CminTime%2CmaxTime"
+        "%2Cgriddap%2Ctabledap",
+    )
+
+    constraints = {
+        "min_lon": -72.8,
+        "min_lat": 40.40,
+        "max_lon": -69.6,
+        "max_lat": 42.02,
+        "min_time": "2022-11-01T00:00:00Z",
+        "max_time": "2022-11-02T00:00:00Z",
+    }
+    utils.get_erddap_metadata(server=server, constraints=constraints)
+    parts = urlparse(requests_mock.call_args.args[0])
+    valid_query = dict(parse_qsl(parts.query))
+    assert valid_query == {
+        "minTime<": "2022-11-02T00:00:00Z",
+        "maxTime>": "2022-11-01T00:00:00Z",
+        "minLongitude<": "-69.6",
+        "maxLongitude>": "-72.8",
+        "minLatitude<": "42.02",
+        "maxLatitude>": "40.4",
+    }


### PR DESCRIPTION
This commit adds appropriate metadata to the source objects. These metadata are retrieved from the allDatasets query and matched to the sources from the search queries. Unfortunately ERDDAP doesn't surface as much information as we would like but this is better than nothing.