### PR TITLE
Fixes case where ERDDAP returns null values where not expected

### DIFF
--- a/tests/test_erddap_cat.py
+++ b/tests/test_erddap_cat.py
@@ -133,6 +133,14 @@ def test_ioos_erddap_catalog_and_source():
         assert cat_sensors[dataset_id].metadata["institution"] is not None
 
 
+@pytest.mark.integration
+def test_erddap_global_conneection():
+    ERDDAPCatalog(
+        "https://erddap.sensors.axds.co/erddap",
+        kwargs_search={"standard_name": "sea_water_temperature"},
+    )
+
+
 def test_invalid_kwarg_search():
     kw = {
         "min_lon": -180,


### PR DESCRIPTION
We found a case today where the ERDDAP JSON response would include null values where they were not expected. The new behavior simply logs a warning and ignores the row when parsing.