### PR TITLE
category_search can use multiple outputs now

### DIFF
--- a/intake_erddap/erddap_cat.py
+++ b/intake_erddap/erddap_cat.py
@@ -219,7 +219,7 @@ class ERDDAPCatalog(Catalog):
             # Currently just take first match, but there could be more than one.
             self.kwargs_search[category] = match_key_to_category(
                 self.server, key, category, cache_store=self.cache_store
-            )[0]
+            )
 
         metadata = metadata or {}
         metadata["kwargs_search"] = self.kwargs_search

--- a/tests/test_erddap_cat.py
+++ b/tests/test_erddap_cat.py
@@ -108,7 +108,7 @@ def test_erddap_catalog_searching_variable(mock_read_csv, load_metadata_mock):
         server=SERVER_URL, kwargs_search=kw, category_search=("standard_name", "temp")
     )
     assert "standard_name" in cat.kwargs_search
-    assert cat.kwargs_search["standard_name"] == "sea_water_temperature"
+    assert cat.kwargs_search["standard_name"] == ["sea_water_temperature"]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Before only the first one was used.