### PR TITLE
new tabledap source options

### DIFF
--- a/intake_erddap/erddap.py
+++ b/intake_erddap/erddap.py
@@ -258,6 +258,7 @@ class TableDAPSource(ERDDAPSource):
                 self._dataframe.loc[
                     ~self._dataframe[qccol].isin([1, 2]), datacol
                 ] = pd.NA
+                self._dataframe.drop(columns=[qccol], inplace=True)
 
     def run_dropna(self):
         """Drop nan rows based on the data columns."""

--- a/intake_erddap/erddap.py
+++ b/intake_erddap/erddap.py
@@ -4,6 +4,7 @@ import typing
 from logging import getLogger
 from typing import List, Optional, Tuple, Type, Union
 
+import cf_pandas  # noqa: F401
 import numpy as np
 import pandas as pd
 import requests
@@ -132,10 +133,13 @@ class TableDAPSource(ERDDAPSource):
         interface. The source will use this object to make HTTP requests to
         ERDDAP in some cases.
     mask_failed_qartod : bool, False
-        If True and `*_qc_agg` columns associated with data columns are available,
-        data values associated with QARTOD flags other than 1 and 2 will be nan'ed out.
+        WARNING ALPHA FEATURE. If True and `*_qc_agg` columns associated with
+        data columns are available, data values associated with QARTOD flags
+        other than 1 and 2 will be nan'ed out. Has not been thoroughly tested.
     dropna : bool, False.
-        If True, rows with data columns of nans will be dropped from data frame.
+        WARNING ALPHA FEATURE. If True, rows with data columns of nans will be
+        dropped from data frame. Has not been thoroughly tested.
+
     Examples
     --------
     Sources are normally returned from a catalog object, but a source can be instantiated directly:
@@ -227,8 +231,6 @@ class TableDAPSource(ERDDAPSource):
     @property
     def data_cols(self):
         """Columns that are not axes, coordinates, nor qc_agg columns."""
-
-        import cf_pandas  # noqa: F401
 
         # find data columns which are what we'll use in the final step to drop nan's
         # don't include dimension/coordinates-type columns (dimcols) nor qc_agg columns (qccols)

--- a/intake_erddap/erddap_cat.py
+++ b/intake_erddap/erddap_cat.py
@@ -102,6 +102,11 @@ class ERDDAPCatalog(Catalog):
         each individual query made to ERDDAP. This is equivalent to a logical
         AND of the results. If the value is ``"union"`` then the results will be
         the union of each resulting dataset. This is equivalent to a logical OR.
+    mask_failed_qartod : bool, False
+        If True and `*_qc_agg` columns associated with data columns are available,
+        data values associated with QARTOD flags other than 1 and 2 will be nan'ed out.
+    dropna : bool, False.
+        If True, rows with data columns of nans will be dropped from data frame.
 
     Attributes
     ----------
@@ -133,6 +138,9 @@ class ERDDAPCatalog(Catalog):
         metadata: dict = None,
         query_type: str = "union",
         cache_period: Optional[Union[int, float]] = 500,
+        open_kwargs: dict = None,
+        mask_failed_qartod: bool = False,
+        dropna: bool = False,
         **kwargs,
     ):
         if server.endswith("/"):
@@ -146,6 +154,9 @@ class ERDDAPCatalog(Catalog):
         self.server = server
         self.search_url = None
         self.cache_store = CacheStore(cache_period=cache_period)
+        self.open_kwargs = open_kwargs or {}
+        self._mask_failed_qartod = mask_failed_qartod
+        self._dropna = dropna
 
         if kwargs_search is not None:
             checks = [
@@ -409,8 +420,15 @@ class ERDDAPCatalog(Catalog):
                 "dataset_id": dataset_id,
                 "protocol": self._protocol,
                 "constraints": {},
+                "open_kwargs": self.open_kwargs,
             }
             if self._protocol == "tabledap":
+                args.update(
+                    {
+                        "mask_failed_qartod": self._mask_failed_qartod,
+                        "dropna": self._dropna,
+                    }
+                )
                 args["constraints"].update(self._get_tabledap_constraints())
 
             metadata = all_metadata.get(dataset_id, {})

--- a/intake_erddap/erddap_cat.py
+++ b/intake_erddap/erddap_cat.py
@@ -103,10 +103,12 @@ class ERDDAPCatalog(Catalog):
         AND of the results. If the value is ``"union"`` then the results will be
         the union of each resulting dataset. This is equivalent to a logical OR.
     mask_failed_qartod : bool, False
-        If True and `*_qc_agg` columns associated with data columns are available,
-        data values associated with QARTOD flags other than 1 and 2 will be nan'ed out.
+        WARNING ALPHA FEATURE. If True and `*_qc_agg` columns associated with
+        data columns are available, data values associated with QARTOD flags
+        other than 1 and 2 will be nan'ed out. Has not been thoroughly tested.
     dropna : bool, False.
-        If True, rows with data columns of nans will be dropped from data frame.
+        WARNING ALPHA FEATURE. If True, rows with data columns of nans will be
+        dropped from data frame. Has not been thoroughly tested.
 
     Attributes
     ----------


### PR DESCRIPTION
* Can now input open_kwargs to pass onto pandas for opening dataset
* also a `mask_failed_qartod` flag to mask out values for which the associated `_qc_agg` flag value is not 1 or 2
* also a `dropna` flag for dropping nans